### PR TITLE
fixed typo scale -> _scale

### DIFF
--- a/Class/PerlinNoise.m
+++ b/Class/PerlinNoise.m
@@ -150,7 +150,7 @@
 
         _functionSelector++;
     }
-    return value / _octaves * scale;
+    return value / _octaves * _scale;
 }
 
 @end


### PR DESCRIPTION
fixed typo, 153 line in  Class / PerlinNoise.m
